### PR TITLE
fix: issue with `local` can only be used in functions

### DIFF
--- a/functions/unarchive
+++ b/functions/unarchive
@@ -1,3 +1,4 @@
+#!/usr/bin/env zsh
 #
 # Extracts the contents of archives.
 #


### PR DESCRIPTION
When using the `unarchive` tool I got the following error, which I suspect to be the result of the runtime environment not being zsh.

```shell
➜ unarchive --help
/Users/<USER>/.zulu/bin/unarchive: line 8: local: can only be used in a function
/Users/<USER>/.zulu/bin/unarchive: line 9: local: can only be used in a function
/Users/<USER>/.zulu/bin/unarchive: line 10: local: can only be used in a function
/Users/<USER>/.zulu/bin/unarchive: line 11: local: can only be used in a function
/Users/<USER>/.zulu/bin/unarchive: line 12: local: can only be used in a function
/Users/<USER>/.zulu/bin/unarchive: line 33: print: command not found
```